### PR TITLE
Add "Slice" for "taxRates" object

### DIFF
--- a/src/features/discountRates/discountRateSlice.test.ts
+++ b/src/features/discountRates/discountRateSlice.test.ts
@@ -9,7 +9,7 @@ const initialState: DiscountRate[] = [
     { id:'50000', value: 50000, discount: 0.15},
 ];
 
-test("should return the initial state", () => {
+test("should return the initial state for Discount Rate", () => {
   expect(
     reducer(undefined, {
       type: "unknown",

--- a/src/features/taxRates/taxRateSlice.test.ts
+++ b/src/features/taxRates/taxRateSlice.test.ts
@@ -1,0 +1,18 @@
+import { DiscountRate } from "../../types/DiscountRate";
+import reducer from "./taxRateSlice";
+
+const initialState = {
+    AUK: 0.0685,
+    WLG: 0.08,
+    WAI: 0.0625,
+    CHC: 0.04,
+    TAS: 0.0825
+};
+
+test("should return the initial state for tax rates", () => {
+  expect(
+    reducer(undefined, {
+      type: "unknown",
+    })
+  ).toMatchObject(initialState);
+});

--- a/src/features/taxRates/taxRateSlice.ts
+++ b/src/features/taxRates/taxRateSlice.ts
@@ -1,0 +1,17 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+    AUK: 0.0685,
+    WLG: 0.08,
+    WAI: 0.0625,
+    CHC: 0.04,
+    TAS: 0.0825
+};
+
+const taxRateSlice = createSlice({
+  name: "taxRates",
+  initialState,
+  reducers: { },
+});
+
+export default taxRateSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from "@reduxjs/toolkit";
 import discountRatesReducer from "../features/discountRates/discountRateSlice"
+import taxRateReducer from "../features/taxRates/taxRateSlice"
 
 export const store = configureStore({
   reducer: {
    discountRates: discountRatesReducer,
+   taxRates: taxRateReducer,
   },
 });
 


### PR DESCRIPTION
Creation of the slice for "taxRates" and the unit test.

![image](https://github.com/ingmiguelfernando/foodstuff-exercise-repository/assets/5770290/6a2bba02-bca7-4698-aeb3-ce7651021829)
